### PR TITLE
SMTP from env; booking handler fixes

### DIFF
--- a/email/email.go
+++ b/email/email.go
@@ -2,11 +2,48 @@ package email
 
 import (
 	_ "embed"
+	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/go-gomail/gomail"
 )
+
+// loadSMTPConfig reads outbound mail settings from the environment (same contract as production SMTP).
+func loadSMTPConfig() (host string, port int, user string, password string, err error) {
+	password = os.Getenv("SMTP_PASSWORD")
+	if password == "" {
+		return "", 0, "", "", fmt.Errorf("SMTP_PASSWORD is not set")
+	}
+	host = os.Getenv("SMTP_HOST")
+	if host == "" {
+		host = "mail.redbudway.com"
+	}
+	port = 587
+	if ps := os.Getenv("SMTP_PORT"); ps != "" {
+		p, convErr := strconv.Atoi(ps)
+		if convErr != nil {
+			return "", 0, "", "", fmt.Errorf("invalid SMTP_PORT: %w", convErr)
+		}
+		port = p
+	}
+	user = os.Getenv("SMTP_USER")
+	if user == "" {
+		user = "service@redbudway.com"
+	}
+	return host, port, user, password, nil
+}
+
+// sendMailMessage sends a fully built gomail message using SMTP_* env (attachments, custom From, etc.).
+func sendMailMessage(m *gomail.Message) error {
+	host, port, user, password, err := loadSMTPConfig()
+	if err != nil {
+		return err
+	}
+	d := gomail.NewDialer(host, port, user, password)
+	return d.DialAndSend(m)
+}
 
 //go:embed html/password.html
 var password string
@@ -17,16 +54,20 @@ var passwordUpdated string
 //go:embed html/email-updated.html
 var emailUpdated string
 
-func email(email, name, subject, body string) error {
+func email(toEmail, name, subject, body string) error {
+	host, port, user, password, err := loadSMTPConfig()
+	if err != nil {
+		return err
+	}
+
 	m := gomail.NewMessage()
-	m.SetAddressHeader("From", "service@redbudway.com", "Redbud Way")
-	m.SetAddressHeader("To", email, name)
+	m.SetAddressHeader("From", user, "Redbud Way")
+	m.SetAddressHeader("To", toEmail, name)
 	m.SetHeader("Subject", subject)
 
 	m.SetBody("text/html", body)
 
-	d := gomail.NewDialer("mail.redbudway.com", 587, "service@redbudway.com", "MerCedEsAmgGt22$")
-
+	d := gomail.NewDialer(host, port, user, password)
 	return d.DialAndSend(m)
 }
 

--- a/email/tradesperson.go
+++ b/email/tradesperson.go
@@ -38,9 +38,7 @@ func SendProviderWelcome(accountEmail string) error {
 	m.SetHeader("Subject", "Welcome provider")
 	m.SetBody("text/html", welcome)
 
-	d := gomail.NewDialer("mail.redbudway.com", 587, "service@redbudway.com", "MerCedEsAmgGt22$")
-
-	return d.DialAndSend(m)
+	return sendMailMessage(m)
 }
 
 func SendTradespersonMessage(businessName, businessEmail, service, message string, stripeCustomer *stripe.Customer, images []string) ([]string, error) {
@@ -59,9 +57,7 @@ func SendTradespersonMessage(businessName, businessEmail, service, message strin
 		m.Attach(image)
 	}
 
-	d := gomail.NewDialer("mail.redbudway.com", 587, "service@redbudway.com", "MerCedEsAmgGt22$")
-
-	return images, d.DialAndSend(m)
+	return images, sendMailMessage(m)
 }
 
 func SendTradespersonBooking(tradesperson models.Tradesperson, stripeCustomer *stripe.Customer, stripeProduct *stripe.Product, timeAndPrice, formRowsCols string) error {
@@ -119,9 +115,7 @@ func SendTradespersonQuoteRequest(tradesperson models.Tradesperson, stripeCustom
 
 	m.SetBody("text/html", body)
 
-	d := gomail.NewDialer("mail.redbudway.com", 587, "service@redbudway.com", "MerCedEsAmgGt22$")
-
-	return images, d.DialAndSend(m)
+	return images, sendMailMessage(m)
 }
 
 func SendTradespersonQuoteAccepted(tradesperson models.Tradesperson, stripeCustomer *stripe.Customer, message string, quote *models.ServiceDetails) error {

--- a/handlers/customer_account.go
+++ b/handlers/customer_account.go
@@ -290,10 +290,6 @@ func PostCustomerCustomerIDFixedPricePriceIDBookHandler(params operations.PostCu
 	var formRowsCols string
 	if len(form) != 0 {
 		formRowsCols = internal.CreateForm(form)
-		if err != nil {
-			log.Printf("Failed to create form, %v", err)
-			return response
-		}
 	}
 
 	go emailHelper(tradesperson, stripePrice, stripeProduct, cuStripeID, timeAndPrice.String(), formRowsCols)
@@ -363,6 +359,7 @@ func PostCustomerCustomerIDSubscriptionPriceIDBookHandler(params operations.Post
 	tradesperson, tpStripeID, tradespersonID, err := database.GetTradespersonAccountByPriceID(priceID)
 	if err != nil {
 		log.Printf("Failed to retrieve tradesperson from price id, %s", priceID)
+		return response
 	}
 
 	sellingFee, err := database.GetTradespersonSellingFee(tradespersonID)
@@ -459,10 +456,6 @@ func PostCustomerCustomerIDSubscriptionPriceIDBookHandler(params operations.Post
 	var formRowsCols string
 	if len(form) != 0 {
 		formRowsCols = internal.CreateForm(form)
-		if err != nil {
-			log.Printf("Failed to create form, %v", err)
-			return response
-		}
 	}
 
 	go emailSubscriptionHelper(tradesperson, stripePrice, cuStripeID, timeAndPrice.String(), formRowsCols)


### PR DESCRIPTION
## Summary
- **Email:** `loadSMTPConfig` / `sendMailMessage` — require `SMTP_PASSWORD`; optional `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`. Remove hardcoded SMTP credentials from `email.go` / `tradesperson.go`.
- **Handlers:** Remove bogus `err` check after `CreateForm`; return on `GetTradespersonAccountByPriceID` failure in subscription book flow.

## Ops
Set `SMTP_PASSWORD` (and optionally other `SMTP_*`) in deployment env.

## Testing
API build may require `pkg-config` for `bimg` in full CI image.


Made with [Cursor](https://cursor.com)